### PR TITLE
Override callback_url

### DIFF
--- a/lib/omniauth/strategies/moves.rb
+++ b/lib/omniauth/strategies/moves.rb
@@ -28,6 +28,10 @@ module OmniAuth
         @raw_info ||= access_token.get('https://api.moves-app.com/api/v1/user/profile').parsed
       end
       
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       private
       
       def client_params


### PR DESCRIPTION
This fixes the following issue #4 

As seen for a lot of other `omniauth-*` gems the OAuth2 gem changes the way they check the integrity of the `callback_url`. Common practice for those gems is to override the `callback_url` and leave the `query_string`part out.
